### PR TITLE
added feature to auto create BIN_PATH

### DIFF
--- a/files.h
+++ b/files.h
@@ -1,6 +1,7 @@
 #ifndef FILES_H
 #define FILES_H
 
+#include <dirent.h>
 #include <stdbool.h>
 #include <stdio.h>
 

--- a/runna.c
+++ b/runna.c
@@ -2,6 +2,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <dirent.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
 
 #define BIN_PATH "./bin"
 
@@ -86,6 +92,18 @@ int exec_compile(char *file_path, char *file_name_no_ext) {
     int path_len = strlen(file_path);
     int file_name_len = strlen(file_name_no_ext);
     int buff_size = path_len + file_name_len + 45; // 35 is for gcc flags and other stuff
+
+    // check for BIN_PATH
+    DIR* dir = opendir(BIN_PATH);
+    if (dir) {
+        // BIN_PATH already exists
+        closedir(dir);
+    } else if (ENOENT == errno) {
+        // need to make BIN_PATH
+        mkdir(BIN_PATH, 0700);
+    } else {
+        perror("probing BIN_PATH failed");
+    }
 
     // create snprintf buffer
     char *compile_cmd = malloc(buff_size);


### PR DESCRIPTION
when I went to try out clings, there was an error due to bin/ not being created, so I added a check in the compile function to see if BIN_PATH exists, if it does not it is created. I also added a header file to exercise.h as it was need to compile. 